### PR TITLE
Fix issue #10: --twitch-oauth-token argument was removed in Streamlink 2.0.0

### DIFF
--- a/twitch-recorder.py
+++ b/twitch-recorder.py
@@ -150,7 +150,7 @@ class TwitchRecorder:
 
                 # start streamlink process
                 subprocess.call(
-                    ["streamlink", "--twitch-disable-ads", "--twitch-oauth-token", self.access_token, "twitch.tv/" + self.username,
+                    ["streamlink", "--twitch-disable-ads", "twitch.tv/" + self.username,
  self.quality, "-o", recorded_filename])
                 
 


### PR DESCRIPTION
This PR fixes issue #10 by removing the `--twitch-oauth-token` argument to Streamlink. It doesn't seem to have had any effect even in older version of Streamlink, so it should be backwards-compatible.

Tested manually with Streamlink 2.0.0.